### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         canfail:
@@ -32,6 +31,10 @@ jobs:
             os: ubuntu-latest
             arch: x64
             canfail: true
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+            canfail: false
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
